### PR TITLE
Javaのバージョンを8に固定

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=8.0.352-amzn

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ PL/SQL デバッガです。
 
 ## requirement
 
-- JDK 1.8+
+- JDK 1.8
+- Oracle Database
+  - 11g で動作確認済み
 
 ## build
 


### PR DESCRIPTION
tools.jar がないと動かないため